### PR TITLE
do not show preview when find-replace works in full screen mode

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -91,6 +91,9 @@ module.exports =
       when 'next' then @resultsView.selectNextResult()
       when 'prev' then @resultsView.selectPreviousResult()
 
+    # Don't show preview when find-and-replace in full screen mode
+    return unless atom.config.get('find-and-replace.openProjectFindResultsInRightPane')
+
     view = @resultsView.find('.selected').view()
     range = view?.match?.range
     return unless range


### PR DESCRIPTION
Hi there, I found some problem. Can you check this out ?

Basically if you `uncheck` open results in right pane for `find-and-replace` package it behaves in a wrong way. 
